### PR TITLE
fix(deps): Upgrade to prisma v4 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^5.6.1",
-    "@prisma/client": "3.14.0",
+    "@prisma/client": "4.15.0",
     "cookie": "^0.5.0",
     "immer": "^9.0.12",
     "jsonwebtoken": "^8.5.1",
@@ -52,7 +52,7 @@
     "eslint-config-prettier": "^8.8.0",
     "jest": "27.5.1",
     "prettier": "^2.8.8",
-    "prisma": "3.14.0",
+    "prisma": "4.15.0",
     "ts-node": "10.7.0",
     "typescript": "4.6.4"
   },

--- a/prisma/migrations/20230611120437_remove_deprecated_referential_integrity_and_add_new_relation_mode_add_indexes_for_relations/migration.sql
+++ b/prisma/migrations/20230611120437_remove_deprecated_referential_integrity_and_add_new_relation_mode_add_indexes_for_relations/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX `ShoppingItem_userId_idx` ON `ShoppingItem`(`userId`);
+
+-- CreateIndex
+CREATE INDEX `ShoppingItemToList_assignedBy_idx` ON `ShoppingItemToList`(`assignedBy`);
+
+-- CreateIndex
+CREATE INDEX `ShoppingItemToList_shoppingListId_idx` ON `ShoppingItemToList`(`shoppingListId`);
+
+-- CreateIndex
+CREATE INDEX `ShoppingItemToList_shoppingItemId_idx` ON `ShoppingItemToList`(`shoppingItemId`);
+
+-- CreateIndex
+CREATE INDEX `ShoppingList_userId_idx` ON `ShoppingList`(`userId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,13 +1,15 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {
   provider             = "mysql"
   url                  = env("DATABASE_URL")
   shadowDatabaseUrl    = env("SHADOW_DATABASE_URL")
-  referentialIntegrity = "prisma"
+  // Initial I have used Planetscale which does not support foreign keys 
+  // check for more info: https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode
+  // I can still switch to `foreignKeys` mode, but don't know how to resolve migration issues(full db reset)
+  relationMode = "prisma"
 }
 
 model User {
@@ -40,6 +42,8 @@ model ShoppingList {
   user          User?                @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId        Int
   shoppingItems ShoppingItemToList[]
+
+  @@index([userId])
 }
 
 model ShoppingItem {
@@ -52,6 +56,8 @@ model ShoppingItem {
   user          User?                @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId        Int
   shoppingLists ShoppingItemToList[]
+
+  @@index([userId])
 }
 
 model ShoppingItemToList {
@@ -67,4 +73,7 @@ model ShoppingItemToList {
   itemPurchased  Boolean
 
   @@id([shoppingListId, shoppingItemId])
+  @@index([assignedBy])
+  @@index([shoppingListId])
+  @@index([shoppingItemId])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,22 +864,22 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
-"@prisma/client@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.14.0.tgz#bb90405c012fcca11f4647d91153ed4c58f3bd48"
-  integrity sha512-atb41UpgTR1MCst0VIbiHTMw8lmXnwUvE1KyUCAkq08+wJyjRE78Due+nSf+7uwqQn+fBFYVmoojtinhlLOSaA==
+"@prisma/client@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.15.0.tgz#f52ec6ca6fbde37395a54b0a9e5da603a9de15f3"
+  integrity sha512-xnROvyABcGiwqRNdrObHVZkD9EjkJYHOmVdlKy1yGgI+XOzvMzJ4tRg3dz1pUlsyhKxXGCnjIQjWW+2ur+YXuw==
   dependencies:
-    "@prisma/engines-version" "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
+    "@prisma/engines-version" "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
 
-"@prisma/engines-version@3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a":
-  version "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a.tgz#4edae57cf6527f35e22cebe75e49214fc0e99ac9"
-  integrity sha512-D+yHzq4a2r2Rrd0ZOW/mTZbgDIkUkD8ofKgusEI1xPiZz60Daks+UM7Me2ty5FzH3p/TgyhBpRrfIHx+ha20RQ==
+"@prisma/engines-version@4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944":
+  version "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz#8d880becf996cffe08c78ad5afab6bc06090c990"
+  integrity sha512-sVOig4tjGxxlYaFcXgE71f/rtFhzyYrfyfNFUsxCIEJyVKU9rdOWIlIwQ2NQ7PntvGnn+x0XuFo4OC1jvPJKzg==
 
-"@prisma/engines@3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a":
-  version "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a.tgz#7fa11bc26a51d450185c816cc0ab8cac673fb4bf"
-  integrity sha512-LwZvI3FY6f43xFjQNRuE10JM5R8vJzFTSmbV9X0Wuhv9kscLkjRlZt0BEoiHmO+2HA3B3xxbMfB5du7ZoSFXGg==
+"@prisma/engines@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.15.0.tgz#d8687a9fda615fab88b75b466931280289de9e26"
+  integrity sha512-FTaOCGs0LL0OW68juZlGxFtYviZa4xdQj/rQEdat2txw0s3Vu/saAPKjNVXfIgUsGXmQ72HPgNr6935/P8FNAA==
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.3"
@@ -4762,12 +4762,12 @@ pretty-format@^27.0.0, pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prisma@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.14.0.tgz#dd67ece37d7b5373e9fd9588971de0024b49be81"
-  integrity sha512-l9MOgNCn/paDE+i1K2fp9NZ+Du4trzPTJsGkaQHVBufTGqzoYHuNk8JfzXuIn0Gte6/ZjyKj652Jq/Lc1tp2yw==
+prisma@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.15.0.tgz#4faa94f0d584828b68468953ff0bc88f37912c8c"
+  integrity sha512-iKZZpobPl48gTcSZVawLMQ3lEy6BnXwtoMj7hluoGFYu2kQ6F9LBuBrUyF95zRVnNo8/3KzLXJXJ5TEnLSJFiA==
   dependencies:
-    "@prisma/engines" "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
+    "@prisma/engines" "4.15.0"
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
Initially I used Planetscale (free tier 😁) while developing this app and Planetscale does not support foriegn keys([operating-without-foreign-key-constraints](https://planetscale.com/docs/learn/operating-without-foreign-key-constraints)). I didn't know that until I stumbled upon a migration issue(#44) with foriegn keys. I liked their motivation now. very good!
